### PR TITLE
SW-2823 Update S3 Client parameters for use in AWS

### DIFF
--- a/src/bootstrap/config.php
+++ b/src/bootstrap/config.php
@@ -11,7 +11,7 @@ return [
             'endpoint' => getenv('AWS_S3_ENDPOINT_URL') ?: null,
             'version' => 'latest',
             'use_path_style_endpoint' => getenv('AWS_S3_USE_PATH_STYLE_ENDPOINT') ?
-                boolval(getenv('AWS_S3_USE_PATH_STYLE_ENDPOINT')) : false,
+                filter_var(getenv('AWS_S3_USE_PATH_STYLE_ENDPOINT'), FILTER_VALIDATE_BOOLEAN) : false,
             'bucket' => getenv('AWS_S3_BUCKET') ?: 'localbucket',
             'prefix' => '/',
             'options' => [

--- a/src/bootstrap/services.php
+++ b/src/bootstrap/services.php
@@ -34,7 +34,12 @@ if (isset($config['aws']['s3']['use_path_style_endpoint']) && $config['aws']['s3
     $s3ClientConfig['use_path_style_endpoint'] = $config['aws']['s3']['use_path_style_endpoint'];
 }
 
-$awsS3Client = new S3Client($s3ClientConfig);
+try {
+    $awsS3Client = new S3Client($s3ClientConfig);
+} catch (Throwable $ex) {
+    $psrLoggerAdapter->critical('Could not create S3 client. S3 config: ' . print_r($s3ClientConfig, true));
+    throw $ex;
+}
 
 $adapter = new AwsS3Adapter(
     $awsS3Client,

--- a/src/bootstrap/services.php
+++ b/src/bootstrap/services.php
@@ -24,14 +24,17 @@ if (empty($config)) {
     throw new InvalidArgumentException('No config found');
 }
 
-$awsS3Client = new S3Client(
-    [
-        'region' => $config['aws']['region'],
-        'version' => $config['aws']['s3']['version'],
-        'endpoint' => $config['aws']['s3']['endpoint'],
-        'use_path_style_endpoint' => $config['aws']['s3']['use_path_style_endpoint'],
-    ]
-);
+$s3ClientConfig = [
+    'region' => $config['aws']['region'],
+    'version' => $config['aws']['s3']['version'],
+];
+
+if (isset($config['aws']['s3']['use_path_style_endpoint']) && $config['aws']['s3']['use_path_style_endpoint'] == true) {
+    $s3ClientConfig['endpoint'] = $config['aws']['s3']['endpoint'];
+    $s3ClientConfig['use_path_style_endpoint'] = $config['aws']['s3']['use_path_style_endpoint'];
+}
+
+$awsS3Client = new S3Client($s3ClientConfig);
 
 $adapter = new AwsS3Adapter(
     $awsS3Client,


### PR DESCRIPTION
When not using path style endpoints, the endpoint and use_path_style_endpoint config values do not need to be set for the S3Client