### PR TITLE
SW-3481 change yml file to point to correct location for Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       separator: "-"
 
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/docker"
     schedule:
       interval: "daily"
       time: "10:00"


### PR DESCRIPTION
PR to change the location where Dependabot looks for the Dockerfile to check docker dependencies. 