### PR TITLE
SW-5809 add template to consumer

### DIFF
--- a/src/NotifyQueueConsumer/Command/Handler/SendToNotifyHandler.php
+++ b/src/NotifyQueueConsumer/Command/Handler/SendToNotifyHandler.php
@@ -29,6 +29,7 @@ class SendToNotifyHandler
     const NOTIFY_TEMPLATE_DOWNLOAD_RR1_LETTER = 'f93687ad-d1e3-4577-83e9-1f5db0748d38';
     const NOTIFY_TEMPLATE_DOWNLOAD_RR2_LETTER = 'd43958ef-4a93-4cd8-abda-c4001785e740';
     const NOTIFY_TEMPLATE_DOWNLOAD_RR3_LETTER = '19610ca0-0225-423a-8f83-729be739be66';
+    const NOTIFY_TEMPLATE_DOWNLOAD_FN14_LETTER = '08a7256f-921c-4cff-a4ef-70d50e2b1847';
 
     public function __construct(Filesystem $filesystem, Client $notifyClient)
     {
@@ -66,6 +67,7 @@ class SendToNotifyHandler
                 'af1', 'af2', 'af3' => self::NOTIFY_TEMPLATE_DOWNLOAD_AF_INVOICE,
                 'bs1' => self::NOTIFY_TEMPLATE_DOWNLOAD_BS1_LETTER,
                 'bs2' => self::NOTIFY_TEMPLATE_DOWNLOAD_BS2_LETTER,
+                'fn14' => self::NOTIFY_TEMPLATE_DOWNLOAD_FN14_LETTER,
                 'rd1' => self::NOTIFY_TEMPLATE_DOWNLOAD_RD1_LETTER,
                 'rd2' => self::NOTIFY_TEMPLATE_DOWNLOAD_RD2_LETTER,
                 'ri2' => self::NOTIFY_TEMPLATE_DOWNLOAD_RI2_LETTER,

--- a/tests/unit/NotifyQueueConsumerTest/Command/Handler/SendToNotifyHandlerTest.php
+++ b/tests/unit/NotifyQueueConsumerTest/Command/Handler/SendToNotifyHandlerTest.php
@@ -112,6 +112,7 @@ class SendToNotifyHandlerTest extends TestCase
     #[ArrayShape([
         'BS1 Template' => "array",
         'BS2 Template' => "array",
+        'FN14 Template' => "array",
         'RD1 Template' => "array",
         'RD2 Template' => "array",
         'RI2 Template' => "array",
@@ -124,6 +125,7 @@ class SendToNotifyHandlerTest extends TestCase
         return [
             'BS1 Template' => ['bs1', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_BS1_LETTER],
             'BS2 Template' => ['bs2', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_BS2_LETTER],
+            'FN14 Template' => ['fn14', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_FN14_LETTER],
             'RD1 Template' => ['rd1', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_RD1_LETTER],
             'RD2 Template' => ['rd2', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_RD2_LETTER],
             'RI2 Template' => ['ri2', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_RI2_LETTER],


### PR DESCRIPTION
This PR is to add the template to the consumer so the correct email template can be found when sending FN14 letters. 