### PR TITLE
SW-5969 Send scheduled letters as email as default

### DIFF
--- a/src/NotifyQueueConsumer/Command/Handler/SendToNotifyHandler.php
+++ b/src/NotifyQueueConsumer/Command/Handler/SendToNotifyHandler.php
@@ -61,7 +61,7 @@ class SendToNotifyHandler
 
         // 3. Send to notify
         $sendBy = $sendToNotifyCommand->getSendBy();
-        if ($sendBy['method'] === 'email' && ($sendBy['documentType'] === 'invoice' || $sendBy['documentType'] === 'letter')) {
+        if ($sendBy['method'] === 'email' && $sendBy['documentType'] === 'letter') {
             $letterTemplate = match ($sendToNotifyCommand->getLetterType()) {
                 'a6' => self::NOTIFY_TEMPLATE_DOWNLOAD_A6_INVOICE,
                 'af1', 'af2', 'af3' => self::NOTIFY_TEMPLATE_DOWNLOAD_AF_INVOICE,

--- a/tests/unit/NotifyQueueConsumerTest/Command/Handler/SendToNotifyHandlerTest.php
+++ b/tests/unit/NotifyQueueConsumerTest/Command/Handler/SendToNotifyHandlerTest.php
@@ -104,7 +104,7 @@ class SendToNotifyHandlerTest extends TestCase
      */
     public function testRetrieveQueueMessageSendToNotifyEmailInvoiceAndReturnCommandExpected(string $letterType, string $letterTemplate): void
     {
-        $data = $this->getData('email', 'invoice', $letterType);
+        $data = $this->getData('email', 'letter', $letterType);
 
         $this->setupForInvoiceAndLettersWithAssertions($data, $letterTemplate);
     }
@@ -334,7 +334,7 @@ class SendToNotifyHandlerTest extends TestCase
      */
     public function testRetrieveQueueMessageSendToNotifyEmailFailsWhenNoNotifyIdReturned(): void
     {
-       $data = $this->getData('email', 'invoice', 'a6');
+       $data = $this->getData('email', 'letter', 'a6');
 
         $contents = "pdf content";
 
@@ -373,7 +373,6 @@ class SendToNotifyHandlerTest extends TestCase
             )
             ->willReturn($response);
 
-        self:
         $this->expectException(UnexpectedValueException::class);
 
         $this->handler->handle($command);
@@ -384,7 +383,7 @@ class SendToNotifyHandlerTest extends TestCase
      */
     public function testRetrieveQueueMessageSendToNotifyEmailFailsWhenNoStatusRetrieved(): void
     {
-        $data = $this->getData('email', 'invoice', null);
+        $data = $this->getData('email', 'letter', null);
 
         $contents = "pdf content";
 

--- a/tests/unit/NotifyQueueConsumerTest/Queue/ConsumerTest.php
+++ b/tests/unit/NotifyQueueConsumerTest/Queue/ConsumerTest.php
@@ -96,30 +96,6 @@ class ConsumerTest extends TestCase
     /**
      * @throws Exception
      */
-    public function testFetchMessageEmailInvoiceSendToNotifyUpdateStatusSuccess(): void
-    {
-        $command = $this->createSendToNotifyCommand('email invoice');
-        $updateDocumentStatusCommand = $this->createUpdateDocumentStatusCommand();
-
-        $this->queueMock->expects(self::once())->method('next')->willReturn($command);
-        $this->sendToNotifyHandlerMock
-            ->expects(self::once())
-            ->method('handle')
-            ->with($command)
-            ->willReturn($updateDocumentStatusCommand);
-        $this->queueMock->expects(self::once())->method('delete')->with($command);
-        $this->updateDocumentStatusHandlerMock
-            ->expects(self::once())
-            ->method('handle')
-            ->with($updateDocumentStatusCommand);
-        $this->loggerMock->expects(self::never())->method('critical');
-
-        $this->consumer->run();
-    }
-
-    /**
-     * @throws Exception
-     */
     public function testFetchMessageEmailLetterSendToNotifyUpdateStatusSuccess(): void
     {
         $command = $this->createSendToNotifyCommand('email letter');
@@ -261,27 +237,6 @@ class ConsumerTest extends TestCase
                     ],
                     'letterType' => 'a6',
                     'pendingOrDueReportType' => 'OPG104',
-                    'caseNumber' => '74442574',
-                ]
-            );
-        }
-        if($sendBy === 'email invoice'){
-            return SendToNotify::fromArray(
-                [
-                    'id' => '1',
-                    'uuid' => 'asd-123',
-                    'filename' => 'this_is_a_test.pdf',
-                    'documentId' => '4545',
-                    'recipientEmail' => 'test@test.com',
-                    'recipientName' => 'Test Test',
-                    'clientFirstName' => 'Devin',
-                    'clientSurname' => 'Bahrke',
-                    'sendBy' => [
-                        'method' => 'email',
-                        'documentType' => 'invoice'
-                    ],
-                    'letterType' => 'a6',
-                    'pendingOrDueReportType' => null,
                     'caseNumber' => '74442574',
                 ]
             );

--- a/tests/unit/NotifyQueueConsumerTest/Queue/SqsAdapterTest.php
+++ b/tests/unit/NotifyQueueConsumerTest/Queue/SqsAdapterTest.php
@@ -134,66 +134,6 @@ class SqsAdapterTest extends TestCase
     /**
      * @throws Exception
      */
-    public function testNextReturnsMessageSuccessEmailInvoice(): void
-    {
-        $awsResult = $this->createMock(Result::class);
-        $config = [
-            'AttributeNames' => ['SentTimestamp'],
-            'MaxNumberOfMessages' => 1,
-            'MessageAttributeNames' => ['All'],
-            'QueueUrl' => $this->queueUrl,
-            'WaitTimeSeconds' => self::DEFAULT_WAIT_TIME,
-        ];
-
-        $rawBody = $this->getMessage(
-            'Test2',
-            'Test2',
-            'email',
-            'invoice',
-            'a6',
-            'test@test.com',
-            'Testy McTestface',
-            'OPG103',
-            '75412368'
-        );
-
-        $rawData = [
-            'ReceiptHandle' => 'handle-12345',
-            'Body' => json_encode($rawBody),
-        ];
-        $expectedResult = SendToNotify::fromArray(
-            [
-                'id' => $rawData['ReceiptHandle'],
-                'uuid' => $rawBody['message']['uuid'],
-                'filename' => $rawBody['message']['filename'],
-                'documentId' => $rawBody['message']['documentId'],
-                'recipientEmail' => $rawBody['message']['recipientEmail'],
-                'recipientName' => $rawBody['message']['recipientName'],
-                'clientFirstName' => $rawBody['message']['clientFirstName'],
-                'clientSurname' => $rawBody['message']['clientSurname'],
-                'sendBy' => $rawBody['message']['sendBy'],
-                'letterType' => $rawBody['message']['letterType'],
-                'pendingOrDueReportType' => $rawBody['message']['pendingOrDueReportType'],
-                'caseNumber' => $rawBody['message']['caseNumber'],
-            ]
-        );
-
-        $awsResult->method('get')->with('Messages')->willReturn([$rawData]);
-
-        $this->sqsClientMock->expects(self::once())->method('receiveMessage')->with($config)->willReturn($awsResult);
-
-        $sqsAdapter = new SqsAdapter($this->sqsClientMock, $this->queueUrl, self::DEFAULT_WAIT_TIME);
-
-        $actualResult = $sqsAdapter->next();
-
-        self::assertEquals($expectedResult->getId(), $actualResult->getId());
-        self::assertEquals($expectedResult->getUuid(), $actualResult->getUuid());
-        self::assertEquals($expectedResult->getFilename(), $actualResult->getFilename());
-    }
-
-    /**
-     * @throws Exception
-     */
     public function testNextReturnsMessageSuccessEmailLetter(): void
     {
         $awsResult = $this->createMock(Result::class);


### PR DESCRIPTION
This PR removes the additional conditional check for `sendBy` if the document contains an invoice as the method of sending a letter can now only be email letter as default if a valid email address exists or post letter as a fallback. 