### PR TITLE
VEGA-1642 consumer not retrying on ClientException

### DIFF
--- a/src/NotifyQueueConsumer/Queue/Consumer.php
+++ b/src/NotifyQueueConsumer/Queue/Consumer.php
@@ -6,6 +6,7 @@ namespace NotifyQueueConsumer\Queue;
 
 use Closure;
 use Exception;
+use GuzzleHttp\Exception\ClientException;
 use NotifyQueueConsumer\Command\Handler\UpdateDocumentStatusHandler;
 use Throwable;
 use Psr\Log\LoggerInterface;
@@ -66,7 +67,7 @@ class Consumer
             $this->logger->info('Updating document status', $logExtras);
             try {
                 $this->updateDocumentStatusHandler->handle($updateDocumentStatusCommand);
-            } catch (UnexpectedValueException $e) {
+            } catch (UnexpectedValueException | ClientException $e) {
                 $this->logger->info($e->getMessage(), $logExtras);
                 $this->sleep->__invoke();
                 $this->logger->info('Updating document status again', $logExtras);

--- a/tests/unit/NotifyQueueConsumerTest/Queue/ConsumerTest.php
+++ b/tests/unit/NotifyQueueConsumerTest/Queue/ConsumerTest.php
@@ -132,30 +132,6 @@ class ConsumerTest extends TestCase
     /**
      * @throws Exception
      */
-    public function testFetchMessageEmailInvoiceSendToNotifyUpdateStatusSuccess(): void
-    {
-        $command = $this->createSendToNotifyCommand('email invoice');
-        $updateDocumentStatusCommand = $this->createUpdateDocumentStatusCommand();
-
-        $this->queueMock->expects(self::once())->method('next')->willReturn($command);
-        $this->sendToNotifyHandlerMock
-            ->expects(self::once())
-            ->method('handle')
-            ->with($command)
-            ->willReturn($updateDocumentStatusCommand);
-        $this->queueMock->expects(self::once())->method('delete')->with($command);
-        $this->updateDocumentStatusHandlerMock
-            ->expects(self::once())
-            ->method('handle')
-            ->with($updateDocumentStatusCommand);
-        $this->loggerMock->expects(self::never())->method('critical');
-
-        $this->consumer->run();
-    }
-
-    /**
-     * @throws Exception
-     */
     public function testFetchMessageEmailLetterSendToNotifyUpdateStatusSuccess(): void
     {
         $command = $this->createSendToNotifyCommand('email letter');


### PR DESCRIPTION
extended catch logic to include ClientException, and added test to retry sending when client exception thrown
VEGA-1642 #patch