### PR TITLE
SW-6421 Add email address to task description when email address fails validation

### DIFF
--- a/src/NotifyQueueConsumer/Command/Handler/SendToNotifyHandler.php
+++ b/src/NotifyQueueConsumer/Command/Handler/SendToNotifyHandler.php
@@ -97,9 +97,9 @@ class SendToNotifyHandler
 
         return UpdateDocumentStatus::fromArray(
             [
+                'documentId' => $sendToNotifyCommand->getDocumentId(),
                 'notifyId' => $notifyId,
                 'notifyStatus' => $notifyStatus,
-                'documentId' => $sendToNotifyCommand->getDocumentId(),
                 'sendByMethod' => $sendBy['method'],
                 'recipientEmailAddress' => $sendToNotifyCommand->getRecipientEmail()
             ]

--- a/src/NotifyQueueConsumer/Command/Handler/SendToNotifyHandler.php
+++ b/src/NotifyQueueConsumer/Command/Handler/SendToNotifyHandler.php
@@ -100,7 +100,8 @@ class SendToNotifyHandler
                 'notifyId' => $notifyId,
                 'notifyStatus' => $notifyStatus,
                 'documentId' => $sendToNotifyCommand->getDocumentId(),
-                'sendByMethod' => $sendBy['method']
+                'sendByMethod' => $sendBy['method'],
+                'recipientEmailAddress' => $sendToNotifyCommand->getRecipientEmail()
             ]
         );
     }

--- a/src/NotifyQueueConsumer/Command/Handler/UpdateDocumentStatusHandler.php
+++ b/src/NotifyQueueConsumer/Command/Handler/UpdateDocumentStatusHandler.php
@@ -46,7 +46,8 @@ class UpdateDocumentStatusHandler
             'notifySendId' => $command->getNotifyId(),
             'notifyStatus' => $this->notifyStatusMapper->toSirius($command->getNotifyStatus()),
             'notifySubStatus' => $command->getNotifyStatus(),
-            'sendByMethod' => $command->getSendByMethod()
+            'sendByMethod' => $command->getSendByMethod(),
+            'recipientEmailAddress' => $command->getRecipientEmailAddress()
         ];
 
         try {

--- a/src/NotifyQueueConsumer/Command/Model/UpdateDocumentStatus.php
+++ b/src/NotifyQueueConsumer/Command/Model/UpdateDocumentStatus.php
@@ -10,6 +10,7 @@ class UpdateDocumentStatus
     protected string $notifyId;
     protected string $notifyStatus;
     protected string $sendByMethod;
+    protected string $recipientEmailAddress;
 
     private function __construct()
     {
@@ -39,6 +40,10 @@ class UpdateDocumentStatus
             AggregateValidationException::addError('Data doesn\'t contain a sendByMethod');
         }
 
+        if (empty($data['recipientEmailAddress'])) {
+            AggregateValidationException::addError('Data doesn\'t contain a recipientEmailAddress');
+        }
+
         AggregateValidationException::checkAndThrow();
 
         $instance = new self();
@@ -47,6 +52,7 @@ class UpdateDocumentStatus
         $instance->notifyId = $data['notifyId'];
         $instance->notifyStatus = $data['notifyStatus'];
         $instance->sendByMethod = $data['sendByMethod'];
+        $instance->recipientEmailAddress = $data['recipientEmailAddress'];
 
         return $instance;
     }
@@ -69,5 +75,10 @@ class UpdateDocumentStatus
     public function getSendByMethod(): string
     {
         return $this->sendByMethod;
+    }
+
+    public function getRecipientEmailAddress(): string
+    {
+        return $this->recipientEmailAddress;
     }
 }

--- a/src/NotifyQueueConsumer/Command/Model/UpdateDocumentStatus.php
+++ b/src/NotifyQueueConsumer/Command/Model/UpdateDocumentStatus.php
@@ -10,7 +10,7 @@ class UpdateDocumentStatus
     protected string $notifyId;
     protected string $notifyStatus;
     protected string $sendByMethod;
-    protected string $recipientEmailAddress;
+    protected ?string $recipientEmailAddress;
 
     private function __construct()
     {
@@ -38,10 +38,6 @@ class UpdateDocumentStatus
 
         if (empty($data['sendByMethod'])) {
             AggregateValidationException::addError('Data doesn\'t contain a sendByMethod');
-        }
-
-        if (empty($data['recipientEmailAddress'])) {
-            AggregateValidationException::addError('Data doesn\'t contain a recipientEmailAddress');
         }
 
         AggregateValidationException::checkAndThrow();
@@ -77,7 +73,7 @@ class UpdateDocumentStatus
         return $this->sendByMethod;
     }
 
-    public function getRecipientEmailAddress(): string
+    public function getRecipientEmailAddress(): ?string
     {
         return $this->recipientEmailAddress;
     }

--- a/src/NotifyQueueConsumer/Queue/SqsAdapter.php
+++ b/src/NotifyQueueConsumer/Queue/SqsAdapter.php
@@ -96,6 +96,7 @@ class SqsAdapter implements QueueInterface
             'uuid',
             'filename',
             'documentId',
+            'sendBy'
         ];
 
         if ($message['sendBy']['method'] === 'email') {

--- a/tests/functional/NotifyQueueConsumerTest/Queue/ConsumerTest.php
+++ b/tests/functional/NotifyQueueConsumerTest/Queue/ConsumerTest.php
@@ -232,7 +232,7 @@ class ConsumerTest extends TestCase
                     $uuid,
                     $destination,
                     $documentId,
-                    '',
+                    'test@test.com',
                     'Test name',
                     'Test2',
                     'Test Surname',

--- a/tests/unit/NotifyQueueConsumerTest/Command/Handler/UpdateDocumentStatusHandlerTest.php
+++ b/tests/unit/NotifyQueueConsumerTest/Command/Handler/UpdateDocumentStatusHandlerTest.php
@@ -56,8 +56,9 @@ class UpdateDocumentStatusHandlerTest extends TestCase
             'documentId' => $command->getDocumentId(),
             'notifySendId' => $command->getNotifyId(),
             'notifyStatus' => $siriusStatus,
-            'sendByMethod' => 'email',
-            'notifySubStatus' => 'accepted'
+            'sendByMethod' => $command->getSendByMethod(),
+            'notifySubStatus' => $command->getNotifyStatus(),
+            'recipientEmailAddress' => $command->getRecipientEmailAddress()
         ];
 
         $this->mockNotifyStatusMapper
@@ -90,8 +91,9 @@ class UpdateDocumentStatusHandlerTest extends TestCase
             'documentId' => $command->getDocumentId(),
             'notifySendId' => $command->getNotifyId(),
             'notifyStatus' => $siriusStatus,
-            'sendByMethod' => 'email',
-            'notifySubStatus' => 'accepted'
+            'sendByMethod' => $command->getSendByMethod(),
+            'notifySubStatus' => $command->getNotifyStatus(),
+            'recipientEmailAddress' => $command->getRecipientEmailAddress()
         ];
 
         $this->mockNotifyStatusMapper
@@ -129,8 +131,9 @@ class UpdateDocumentStatusHandlerTest extends TestCase
             'documentId' => $command->getDocumentId(),
             'notifySendId' => $command->getNotifyId(),
             'notifyStatus' => $siriusStatus,
-            'sendByMethod' => 'email',
-            'notifySubStatus' => 'accepted'
+            'sendByMethod' => $command->getSendByMethod(),
+            'notifySubStatus' => $command->getNotifyStatus(),
+            'recipientEmailAddress' => $command->getRecipientEmailAddress()
         ];
 
         $this->mockNotifyStatusMapper
@@ -158,10 +161,12 @@ class UpdateDocumentStatusHandlerTest extends TestCase
     private function createUpdateDocumentStatusCommand(): UpdateDocumentStatus
     {
         return UpdateDocumentStatus::fromArray([
+            'documentId' => '4545',
             'notifyId' => '1',
             'notifyStatus' => 'accepted',
-            'documentId' => '4545',
-            'sendByMethod' => 'email'
+            'sendByMethod' => 'email',
+            'notifySubStatus' => 'accepted',
+            'recipientEmailAddress' => 'test@test.com'
         ]);
     }
 }

--- a/tests/unit/NotifyQueueConsumerTest/Command/Model/UpdateDocumentStatusTest.php
+++ b/tests/unit/NotifyQueueConsumerTest/Command/Model/UpdateDocumentStatusTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class UpdateDocumentStatusTest extends TestCase
 {
-    public function testFromArraySuccess(): void
+    public function testFromArraySuccessSupervision(): void
     {
         $data = [
             'notifyId' => '1',
@@ -18,6 +18,25 @@ class UpdateDocumentStatusTest extends TestCase
             'documentId' => '4545',
             'sendByMethod' => 'email',
             'recipientEmailAddress' => 'test@test.com'
+        ];
+
+        $command = UpdateDocumentStatus::fromArray($data);
+
+        self::assertEquals($data['notifyId'], $command->getNotifyId());
+        self::assertEquals($data['notifyStatus'], $command->getNotifyStatus());
+        self::assertEquals($data['documentId'], $command->getDocumentId());
+        self::assertEquals($data['sendByMethod'], $command->getSendByMethod());
+        self::assertEquals($data['recipientEmailAddress'], $command->getRecipientEmailAddress());
+    }
+
+    public function testFromArraySuccessLpa(): void
+    {
+        $data = [
+            'notifyId' => '1',
+            'notifyStatus' => 'accepted',
+            'documentId' => '4545',
+            'sendByMethod' => 'post',
+            'recipientEmailAddress' => null
         ];
 
         $command = UpdateDocumentStatus::fromArray($data);
@@ -64,22 +83,17 @@ class UpdateDocumentStatusTest extends TestCase
                 ['notifyId' => '1', 'notifyStatus' => 'accepted', 'documentId' => '4545', 'recipientEmailAddress' => 'test@test.com'],
                 'Data doesn\'t contain a sendByMethod'
             ],
-            'missing recipientEmailAddress' => [
-                ['notifyId' => '1', 'notifyStatus' => 'accepted', 'documentId' => '4545', 'sendByMethod' => 'email'],
-                'Data doesn\'t contain a recipientEmailAddress'
-            ],
             'non-numeric documentId' => [
                 ['notifyId' => '1', 'notifyStatus' => 'accepted', 'documentId' => 'word', 'recipientEmailAddress' => 'test@test.com'],
                 'Data doesn\'t contain a numeric documentId'
             ],
-            'missing all' => [
+            'missing mandatory' => [
                 [],
                 implode(', ', [
                         'Data doesn\'t contain a numeric documentId',
                         'Data doesn\'t contain a notifyId',
                         'Data doesn\'t contain a notifyStatus',
-                        'Data doesn\'t contain a sendByMethod',
-                        'Data doesn\'t contain a recipientEmailAddress',
+                        'Data doesn\'t contain a sendByMethod'
                     ]
                 ),
             ],

--- a/tests/unit/NotifyQueueConsumerTest/Command/Model/UpdateDocumentStatusTest.php
+++ b/tests/unit/NotifyQueueConsumerTest/Command/Model/UpdateDocumentStatusTest.php
@@ -16,7 +16,8 @@ class UpdateDocumentStatusTest extends TestCase
             'notifyId' => '1',
             'notifyStatus' => 'accepted',
             'documentId' => '4545',
-            'sendByMethod' => 'email'
+            'sendByMethod' => 'email',
+            'recipientEmailAddress' => 'test@test.com'
         ];
 
         $command = UpdateDocumentStatus::fromArray($data);
@@ -25,6 +26,7 @@ class UpdateDocumentStatusTest extends TestCase
         self::assertEquals($data['notifyStatus'], $command->getNotifyStatus());
         self::assertEquals($data['documentId'], $command->getDocumentId());
         self::assertEquals($data['sendByMethod'], $command->getSendByMethod());
+        self::assertEquals($data['recipientEmailAddress'], $command->getRecipientEmailAddress());
     }
 
     /**
@@ -47,23 +49,27 @@ class UpdateDocumentStatusTest extends TestCase
     {
         return [
             'missing notifyId' => [
-                ['notifyStatus' => 'accepted', 'documentId' => '4545', 'sendByMethod' => 'email'],
+                ['notifyStatus' => 'accepted', 'documentId' => '4545', 'sendByMethod' => 'email', 'recipientEmailAddress' => 'test@test.com'],
                 'Data doesn\'t contain a notifyId'
             ],
             'missing notifyStatus' => [
-                ['notifyId' => '1', 'documentId' => '4545', 'sendByMethod' => 'email'],
+                ['notifyId' => '1', 'documentId' => '4545', 'sendByMethod' => 'email', 'recipientEmailAddress' => 'test@test.com'],
                 'Data doesn\'t contain a notifyStatus'
             ],
             'missing documentId' => [
-                ['notifyId' => '1', 'notifyStatus' => 'accepted', 'sendByMethod' => 'email'],
+                ['notifyId' => '1', 'notifyStatus' => 'accepted', 'sendByMethod' => 'email', 'recipientEmailAddress' => 'test@test.com'],
                 'Data doesn\'t contain a numeric documentId'
             ],
             'missing sendByMethod' => [
-                ['notifyId' => '1', 'notifyStatus' => 'accepted', 'documentId' => '4545'],
+                ['notifyId' => '1', 'notifyStatus' => 'accepted', 'documentId' => '4545', 'recipientEmailAddress' => 'test@test.com'],
                 'Data doesn\'t contain a sendByMethod'
             ],
+            'missing recipientEmailAddress' => [
+                ['notifyId' => '1', 'notifyStatus' => 'accepted', 'documentId' => '4545', 'sendByMethod' => 'email'],
+                'Data doesn\'t contain a recipientEmailAddress'
+            ],
             'non-numeric documentId' => [
-                ['notifyId' => '1', 'notifyStatus' => 'accepted', 'documentId' => 'word'],
+                ['notifyId' => '1', 'notifyStatus' => 'accepted', 'documentId' => 'word', 'recipientEmailAddress' => 'test@test.com'],
                 'Data doesn\'t contain a numeric documentId'
             ],
             'missing all' => [
@@ -73,6 +79,7 @@ class UpdateDocumentStatusTest extends TestCase
                         'Data doesn\'t contain a notifyId',
                         'Data doesn\'t contain a notifyStatus',
                         'Data doesn\'t contain a sendByMethod',
+                        'Data doesn\'t contain a recipientEmailAddress',
                     ]
                 ),
             ],

--- a/tests/unit/NotifyQueueConsumerTest/Queue/ConsumerTest.php
+++ b/tests/unit/NotifyQueueConsumerTest/Queue/ConsumerTest.php
@@ -307,7 +307,8 @@ class ConsumerTest extends TestCase
                 'notifyId' => '1',
                 'notifyStatus' => 'accepted',
                 'documentId' => '4545',
-                'sendByMethod' => 'email'
+                'sendByMethod' => 'email',
+                'recipientEmailAddress' => 'test@test.com'
             ]
         );
     }


### PR DESCRIPTION
This PR is to add the email address of the recipient to the tasks where their email fails validation from Notify. This adds the functionality to send the email address back to Sirius where Notify deems that the  email address does not exist / or is not receiving emails currently. 

#minor