### PR TITLE
SW-6361 add case management email logic to the SendToNotifyHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Functional tests
 
     # Ensure the consumer is built before attempting to run the functional tests 
     
-    docker-compose --project-name notify-queue-consumer up -d localstack
+    docker-compose --project-name notify-queue-consumer up -d --force-recreate localstack
     docker-compose --project-name notify-queue-consumer up -d --build --force-recreate consumer-mock-notify
     docker-compose --project-name notify-queue-consumer up -d --build --force-recreate consumer-mock-sirius
     docker-compose --project-name notify-queue-consumer run --rm test-functional

--- a/src/NotifyQueueConsumer/Command/Handler/SendToNotifyHandler.php
+++ b/src/NotifyQueueConsumer/Command/Handler/SendToNotifyHandler.php
@@ -31,6 +31,9 @@ class SendToNotifyHandler
     const NOTIFY_TEMPLATE_DOWNLOAD_RR3_LETTER = '19610ca0-0225-423a-8f83-729be739be66';
     const NOTIFY_TEMPLATE_DOWNLOAD_FN14_LETTER = '08a7256f-921c-4cff-a4ef-70d50e2b1847';
     const NOTIFY_EMAIL_HEALTH_AND_WELFARE = '9b1dfc66-8ccb-4db8-b4e7-17f03f487874';
+    const NOTIFY_EMAIL_PFA_LAY = '27e5deb5-8ea0-4d91-83d1-ae4145c351f9';
+    const NOTIFY_EMAIL_PFA_PRO = '3e6753b7-6602-4363-8c9a-c88d02b239ba';
+    const NOTIFY_EMAIL_PFA_PA = 'd8b4e115-5688-4161-82ca-82a93344a21f';
 
     public function __construct(Filesystem $filesystem, Client $notifyClient)
     {
@@ -79,8 +82,11 @@ class SendToNotifyHandler
                 default => null,
             };
 
-            $replyToEmail = match ($sendToNotifyCommand->getOrderType()) {
+            $replyToEmail = match ($sendToNotifyCommand->getReplyToType()) {
                 'HW' => self::NOTIFY_EMAIL_HEALTH_AND_WELFARE,
+                'PFA LAY' => self::NOTIFY_EMAIL_PFA_LAY,
+                'PFA PRO' => self::NOTIFY_EMAIL_PFA_PRO,
+                'PFA PA' => self::NOTIFY_EMAIL_PFA_PA,
                 default => null
             };
             $response = $this->sendEmailToNotify(

--- a/src/NotifyQueueConsumer/Command/Model/SendToNotify.php
+++ b/src/NotifyQueueConsumer/Command/Model/SendToNotify.php
@@ -21,7 +21,7 @@ class SendToNotify
      */
     protected array $sendBy;
     protected ?string $letterType;
-    protected ?string $orderType;
+    protected ?string $replyToType;
 
     private function __construct()
     {
@@ -66,7 +66,7 @@ class SendToNotify
         $instance->letterType = $data['letterType'];
         $instance->pendingOrDueReportType = $data['pendingOrDueReportType'];
         $instance->caseNumber = $data['caseNumber'];
-        $instance->orderType = $data['orderType'];
+        $instance->replyToType = $data['replyToType'];
 
         return $instance;
     }
@@ -134,8 +134,8 @@ class SendToNotify
         return $this->caseNumber;
     }
 
-    public function getOrderType(): ?string
+    public function getReplyToType(): ?string
     {
-        return $this->orderType;
+        return $this->replyToType;
     }
 }

--- a/src/NotifyQueueConsumer/Queue/SqsAdapter.php
+++ b/src/NotifyQueueConsumer/Queue/SqsAdapter.php
@@ -56,7 +56,7 @@ class SqsAdapter implements QueueInterface
             'letterType' => $message['letterType'],
             'pendingOrDueReportType' => $message['pendingOrDueReportType'],
             'caseNumber' => $message['caseNumber'],
-            'orderType' => $message['orderType']
+            'replyToType' => $message['replyToType']
         ]);
     }
 

--- a/tests/functional/NotifyQueueConsumerTest/Queue/ConsumerTest.php
+++ b/tests/functional/NotifyQueueConsumerTest/Queue/ConsumerTest.php
@@ -228,7 +228,7 @@ class ConsumerTest extends TestCase
                     '{"message":{"uuid":"%s","filename":"%s","documentId":"%d", 
                     "recipientEmail":"%s", "recipientName":"%s", "clientFirstName":"%s", "clientSurname":"%s",
                     "sendBy":{"method": "post", "documentType": "letter"}, "letterType":"%s", "pendingOrDueReportType":"%s",
-                     "caseNumber":"%s", "orderType":"%s"}}',
+                     "caseNumber":"%s", "replyToType":"%s"}}',
                     $uuid,
                     $destination,
                     $documentId,

--- a/tests/unit/NotifyQueueConsumerTest/Command/Handler/SendToNotifyHandlerTest.php
+++ b/tests/unit/NotifyQueueConsumerTest/Command/Handler/SendToNotifyHandlerTest.php
@@ -126,10 +126,10 @@ class SendToNotifyHandlerTest extends TestCase
             'BS1 Template' => ['bs1', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_BS1_LETTER, 'HW'],
             'BS2 Template' => ['bs2', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_BS2_LETTER, 'HW'],
             'FN14 Template' => ['fn14', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_FN14_LETTER, null],
-            'RD1 Template' => ['rd1', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_RD1_LETTER, 'HW'],
-            'RD2 Template' => ['rd2', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_RD2_LETTER, 'HW'],
-            'RI2 Template' => ['ri2', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_RI2_LETTER, 'HW'],
-            'RI3 Template' => ['ri3', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_RI3_LETTER, 'HW'],
+            'RD1 Template' => ['rd1', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_RD1_LETTER, 'PFA LAY'],
+            'RD2 Template' => ['rd2', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_RD2_LETTER, 'PFA PRO'],
+            'RI2 Template' => ['ri2', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_RI2_LETTER, 'PFA PA'],
+            'RI3 Template' => ['ri3', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_RI3_LETTER, 'PFA'],
             'RR1 Template' => ['rr1', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_RR1_LETTER, 'HW'],
             'RR2 Template' => ['rr2', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_RR2_LETTER, 'HW'],
             'RR3 Template' => ['rr3', SendToNotifyHandler::NOTIFY_TEMPLATE_DOWNLOAD_RR3_LETTER, 'HW'],
@@ -140,9 +140,9 @@ class SendToNotifyHandlerTest extends TestCase
      * @dataProvider annualReportLetterData
      * @throws FileNotFoundException
      */
-    public function testRetrieveQueueMessageSendToNotifyEmailLetterAndReturnCommandExpected(string $letterType, string $letterTemplate, ?string $orderType): void
+    public function testRetrieveQueueMessageSendToNotifyEmailLetterAndReturnCommandExpected(string $letterType, string $letterTemplate, ?string $replyToType): void
     {
-        $data = $this->getData('email', 'letter', $letterType, $orderType);
+        $data = $this->getData('email', 'letter', $letterType, $replyToType);
 
         $this->setupForInvoiceAndLettersWithAssertions($data, $letterTemplate);
     }
@@ -470,7 +470,7 @@ class SendToNotifyHandlerTest extends TestCase
         ];
     }
 
-    private function getData(string $sendByMethod, string $sendByDocType, ?string $letterType, ?string $orderType): array
+    private function getData(string $sendByMethod, string $sendByDocType, ?string $letterType, ?string $replyToType): array
     {
         return [
             'id' => '123',
@@ -488,7 +488,7 @@ class SendToNotifyHandlerTest extends TestCase
             'letterType' => $letterType,
             'pendingOrDueReportType' => 'OPG103',
             'caseNumber' => '74442574',
-            'orderType' => $orderType
+            'replyToType' => $replyToType
         ];
     }
 

--- a/tests/unit/NotifyQueueConsumerTest/Command/Model/SendToNotifyTest.php
+++ b/tests/unit/NotifyQueueConsumerTest/Command/Model/SendToNotifyTest.php
@@ -10,7 +10,21 @@ use PHPUnit\Framework\TestCase;
 
 class SendToNotifyTest extends TestCase
 {
-    public function testFromArraySuccess(): void
+
+    public static function fromArrayProvider (): array
+    {
+        return [
+            ["HW"],
+            ["PFA LAY"],
+            ["PFA PRO"],
+            ["PFA PA"],
+            [null]
+        ];
+    }
+    /**
+     * @dataProvider fromArrayProvider
+     */
+    public function testFromArraySuccess(?string $replyToType): void
     {
         $data = [
             'id' => '123',
@@ -28,7 +42,7 @@ class SendToNotifyTest extends TestCase
             'letterType' => 'a6',
             'pendingOrDueReportType' => 'OPG102',
             'caseNumber' => '74442574',
-            'orderType' => 'HW'
+            'replyToType' => $replyToType
         ];
 
         $command = SendToNotify::fromArray($data);

--- a/tests/unit/NotifyQueueConsumerTest/Queue/ConsumerTest.php
+++ b/tests/unit/NotifyQueueConsumerTest/Queue/ConsumerTest.php
@@ -274,7 +274,7 @@ class ConsumerTest extends TestCase
                     'letterType' => 'a6',
                     'pendingOrDueReportType' => 'OPG104',
                     'caseNumber' => '74442574',
-                    'orderType' => 'HW'
+                    'replyToType' => 'HW'
                 ]
             );
         }
@@ -295,7 +295,7 @@ class ConsumerTest extends TestCase
                 'letterType' => 'a6',
                 'pendingOrDueReportType' => null,
                 'caseNumber' => '74442574',
-                'orderType' => 'HW'
+                'replyToType' => 'HW'
             ]
         );
     }

--- a/tests/unit/NotifyQueueConsumerTest/Queue/SqsAdapterTest.php
+++ b/tests/unit/NotifyQueueConsumerTest/Queue/SqsAdapterTest.php
@@ -76,7 +76,7 @@ class SqsAdapterTest extends TestCase
                 'letterType' => $rawBody['message']['letterType'],
                 'pendingOrDueReportType' => $rawBody['message']['pendingOrDueReportType'],
                 'caseNumber' => $rawBody['message']['caseNumber'],
-                'orderType' => $rawBody['message']['orderType']
+                'replyToType' => $rawBody['message']['replyToType']
             ]
         );
 
@@ -136,7 +136,7 @@ class SqsAdapterTest extends TestCase
                 'letterType' => $rawBody['message']['letterType'],
                 'pendingOrDueReportType' => $rawBody['message']['pendingOrDueReportType'],
                 'caseNumber' => $rawBody['message']['caseNumber'],
-                'orderType' => $rawBody['message']['orderType']
+                'replyToType' => $rawBody['message']['replyToType']
             ]
         );
 
@@ -198,7 +198,7 @@ class SqsAdapterTest extends TestCase
                 'letterType' => $rawBody['message']['letterType'],
                 'pendingOrDueReportType' => $rawBody['message']['pendingOrDueReportType'],
                 'caseNumber' => $rawBody['message']['caseNumber'],
-                'orderType' => $rawBody['message']['orderType']
+                'replyToType' => $rawBody['message']['replyToType']
             ]
         );
 
@@ -313,7 +313,7 @@ class SqsAdapterTest extends TestCase
                 'letterType' => null,
                 'pendingOrDueReportType' => null,
                 'caseNumber' => '74442574',
-                'orderType' => 'HW'
+                'replyToType' => 'HW'
             ]
         );
 
@@ -342,7 +342,7 @@ class SqsAdapterTest extends TestCase
         ?string $recipientName,
         ?string $pendingOrDueReportType,
         ?string $caseNumber,
-        ?string $orderType
+        ?string $replyToType
     ): array
     {
         return ['message' => [
@@ -360,7 +360,7 @@ class SqsAdapterTest extends TestCase
             'letterType' => $letterType,
             'pendingOrDueReportType' => $pendingOrDueReportType,
             'caseNumber' => $caseNumber,
-            'orderType' => $orderType
+            'replyToType' => $replyToType
         ]];
     }
 }


### PR DESCRIPTION
This PR is to set the reply-to email address for all scheduled annual report letter types sent via Notify where the order is not HW or Hybrid. The replyToEmail is set according to the deputy type of the recipient.