### PR TITLE
Upgrade Flysystem to v3 (#594)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     "guzzlehttp/guzzle": "^7.0",
     "guzzlehttp/psr7": "^2.0",
     "laminas/laminas-log": "^2.12",
-    "league/flysystem": "^1.0",
-    "league/flysystem-aws-s3-v3": "^1.0",
+    "league/flysystem": "^3.0.0",
+    "league/flysystem-aws-s3-v3": "^3.0.0",
     "lcobucci/jwt": "^5.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e6f3b3bf08abe890890e2a0d52e160a7",
+    "content-hash": "d0b5b1f0453a5951848f7cfe04c59c29",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -911,54 +911,52 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.1.10",
+            "version": "3.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "3239285c825c152bcc315fe0e87d6b55f5972ed1"
+                "reference": "1b2aa10f2326e0351399b8ce68e287d8e9209a83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/3239285c825c152bcc315fe0e87d6b55f5972ed1",
-                "reference": "3239285c825c152bcc315fe0e87d6b55f5972ed1",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/1b2aa10f2326e0351399b8ce68e287d8e9209a83",
+                "reference": "1b2aa10f2326e0351399b8ce68e287d8e9209a83",
                 "shasum": ""
             },
             "require": {
-                "ext-fileinfo": "*",
-                "league/mime-type-detection": "^1.3",
-                "php": "^7.2.5 || ^8.0"
+                "league/flysystem-local": "^3.0.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
             },
             "conflict": {
-                "league/flysystem-sftp": "<1.0.6"
+                "async-aws/core": "<1.19.0",
+                "async-aws/s3": "<1.14.0",
+                "aws/aws-sdk-php": "3.209.31 || 3.210.0",
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1",
+                "phpseclib/phpseclib": "3.0.15",
+                "symfony/http-client": "<5.2"
             },
             "require-dev": {
-                "phpspec/prophecy": "^1.11.1",
-                "phpunit/phpunit": "^8.5.8"
-            },
-            "suggest": {
-                "ext-ftp": "Allows you to use FTP server storage",
-                "ext-openssl": "Allows you to use FTPS server storage",
-                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
-                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
-                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
-                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
-                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
-                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
-                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
-                "league/flysystem-webdav": "Allows you to use WebDAV storage",
-                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
-                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
-                "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
+                "async-aws/s3": "^1.5 || ^2.0",
+                "async-aws/simple-s3": "^1.1 || ^2.0",
+                "aws/aws-sdk-php": "^3.220.0",
+                "composer/semver": "^3.0",
+                "ext-fileinfo": "*",
+                "ext-ftp": "*",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^3.5",
+                "google/cloud-storage": "^1.23",
+                "microsoft/azure-storage-blob": "^1.1",
+                "phpseclib/phpseclib": "^3.0.14",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^9.5.11|^10.0",
+                "sabre/dav": "^4.3.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
-                    "League\\Flysystem\\": "src/"
+                    "League\\Flysystem\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -968,73 +966,67 @@
             "authors": [
                 {
                     "name": "Frank de Jonge",
-                    "email": "info@frenky.net"
+                    "email": "info@frankdejonge.nl"
                 }
             ],
-            "description": "Filesystem abstraction: Many filesystems, one API.",
+            "description": "File storage abstraction for PHP",
             "keywords": [
-                "Cloud Files",
                 "WebDAV",
-                "abstraction",
                 "aws",
                 "cloud",
-                "copy.com",
-                "dropbox",
-                "file systems",
+                "file",
                 "files",
                 "filesystem",
                 "filesystems",
                 "ftp",
-                "rackspace",
-                "remote",
                 "s3",
                 "sftp",
                 "storage"
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/1.1.10"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.19.0"
             },
             "funding": [
                 {
-                    "url": "https://offset.earth/frankdejonge",
-                    "type": "other"
+                    "url": "https://ecologi.com/frankdejonge",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
                 }
             ],
-            "time": "2022-10-04T09:16:37+00:00"
+            "time": "2023-11-07T09:04:28+00:00"
         },
         {
             "name": "league/flysystem-aws-s3-v3",
-            "version": "1.0.30",
+            "version": "3.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem-aws-s3-v3.git",
-                "reference": "af286f291ebab6877bac0c359c6c2cb017eb061d"
+                "reference": "03be643c8ed4dea811d946101be3bc875b5cf214"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/af286f291ebab6877bac0c359c6c2cb017eb061d",
-                "reference": "af286f291ebab6877bac0c359c6c2cb017eb061d",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/03be643c8ed4dea811d946101be3bc875b5cf214",
+                "reference": "03be643c8ed4dea811d946101be3bc875b5cf214",
                 "shasum": ""
             },
             "require": {
-                "aws/aws-sdk-php": "^3.20.0",
-                "league/flysystem": "^1.0.40",
-                "php": ">=5.5.0"
+                "aws/aws-sdk-php": "^3.220.0",
+                "league/flysystem": "^3.10.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
             },
-            "require-dev": {
-                "henrikbjorn/phpspec-code-coverage": "~1.0.1",
-                "phpspec/phpspec": "^2.0.0"
+            "conflict": {
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
-                    "League\\Flysystem\\AwsS3v3\\": "src/"
+                    "League\\Flysystem\\AwsS3V3\\": ""
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1044,29 +1036,94 @@
             "authors": [
                 {
                     "name": "Frank de Jonge",
-                    "email": "info@frenky.net"
+                    "email": "info@frankdejonge.nl"
                 }
             ],
-            "description": "Flysystem adapter for the AWS S3 SDK v3.x",
+            "description": "AWS S3 filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "aws",
+                "file",
+                "files",
+                "filesystem",
+                "s3",
+                "storage"
+            ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem-aws-s3-v3/issues",
-                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/1.0.30"
+                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/3.19.0"
             },
             "funding": [
                 {
-                    "url": "https://offset.earth/frankdejonge",
+                    "url": "https://ecologi.com/frankdejonge",
                     "type": "custom"
                 },
                 {
                     "url": "https://github.com/frankdejonge",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2022-07-02T13:51:38+00:00"
+            "time": "2023-11-06T20:35:28+00:00"
+        },
+        {
+            "name": "league/flysystem-local",
+            "version": "3.19.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-local.git",
+                "reference": "8d868217f9eeb4e9a7320db5ccad825e9a7a4076"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/8d868217f9eeb4e9a7320db5ccad825e9a7a4076",
+                "reference": "8d868217f9eeb4e9a7320db5ccad825e9a7a4076",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "league/flysystem": "^3.0.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\Local\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "Local filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "file",
+                "files",
+                "filesystem",
+                "local"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/flysystem-local/issues",
+                "source": "https://github.com/thephpleague/flysystem-local/tree/3.19.0"
+            },
+            "funding": [
+                {
+                    "url": "https://ecologi.com/frankdejonge",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-11-06T20:35:28+00:00"
         },
         {
             "name": "league/mime-type-detection",

--- a/src/NotifyQueueConsumer/Command/Handler/SendToNotifyHandler.php
+++ b/src/NotifyQueueConsumer/Command/Handler/SendToNotifyHandler.php
@@ -18,23 +18,23 @@ class SendToNotifyHandler
     private Filesystem $filesystem;
     private Client $notifyClient;
 
-    const NOTIFY_TEMPLATE_DOWNLOAD_A6_INVOICE = '9286a7db-a316-4103-a1c7-7bc1fdbbaa81';
-    const NOTIFY_TEMPLATE_DOWNLOAD_AF_INVOICE = '017b664c-2776-497b-ad6e-b25b8a365ae0';
-    const NOTIFY_TEMPLATE_DOWNLOAD_BS1_LETTER = '3dc53e2c-7e90-4e5f-95ef-8e7a98a6ee55';
-    const NOTIFY_TEMPLATE_DOWNLOAD_BS2_LETTER = '228746a3-a445-412d-995e-ae60af86b63d';
-    const NOTIFY_TEMPLATE_DOWNLOAD_RD1_LETTER = 'ed08b8c0-dcd6-4cd4-9798-779189e0abe8';
-    const NOTIFY_TEMPLATE_DOWNLOAD_RD2_LETTER = '7bc45244-1545-4978-9a01-926d1291b1df';
-    const NOTIFY_TEMPLATE_DOWNLOAD_RI2_LETTER = 'd17bb689-52d1-4d73-a501-9955282cfe2e';
-    const NOTIFY_TEMPLATE_DOWNLOAD_RI3_LETTER = '473de8af-c59f-4b7e-8e12-240450ec3fb4';
-    const NOTIFY_TEMPLATE_DOWNLOAD_RR1_LETTER = 'f93687ad-d1e3-4577-83e9-1f5db0748d38';
-    const NOTIFY_TEMPLATE_DOWNLOAD_RR2_LETTER = 'd43958ef-4a93-4cd8-abda-c4001785e740';
-    const NOTIFY_TEMPLATE_DOWNLOAD_RR3_LETTER = '19610ca0-0225-423a-8f83-729be739be66';
-    const NOTIFY_TEMPLATE_DOWNLOAD_FN14_LETTER = '08a7256f-921c-4cff-a4ef-70d50e2b1847';
-    const NOTIFY_EMAIL_HEALTH_AND_WELFARE = '9b1dfc66-8ccb-4db8-b4e7-17f03f487874';
-    const NOTIFY_EMAIL_PFA_LAY = '27e5deb5-8ea0-4d91-83d1-ae4145c351f9';
-    const NOTIFY_EMAIL_PFA_PRO = '3e6753b7-6602-4363-8c9a-c88d02b239ba';
-    const NOTIFY_EMAIL_PFA_PA = 'd8b4e115-5688-4161-82ca-82a93344a21f';
-    const NOTIFY_EMAIL_FINANCE = 'f1e5faf6-e6aa-4beb-b6b8-cfa418482653';
+    public const NOTIFY_TEMPLATE_DOWNLOAD_A6_INVOICE = '9286a7db-a316-4103-a1c7-7bc1fdbbaa81';
+    public const NOTIFY_TEMPLATE_DOWNLOAD_AF_INVOICE = '017b664c-2776-497b-ad6e-b25b8a365ae0';
+    public const NOTIFY_TEMPLATE_DOWNLOAD_BS1_LETTER = '3dc53e2c-7e90-4e5f-95ef-8e7a98a6ee55';
+    public const NOTIFY_TEMPLATE_DOWNLOAD_BS2_LETTER = '228746a3-a445-412d-995e-ae60af86b63d';
+    public const NOTIFY_TEMPLATE_DOWNLOAD_RD1_LETTER = 'ed08b8c0-dcd6-4cd4-9798-779189e0abe8';
+    public const NOTIFY_TEMPLATE_DOWNLOAD_RD2_LETTER = '7bc45244-1545-4978-9a01-926d1291b1df';
+    public const NOTIFY_TEMPLATE_DOWNLOAD_RI2_LETTER = 'd17bb689-52d1-4d73-a501-9955282cfe2e';
+    public const NOTIFY_TEMPLATE_DOWNLOAD_RI3_LETTER = '473de8af-c59f-4b7e-8e12-240450ec3fb4';
+    public const NOTIFY_TEMPLATE_DOWNLOAD_RR1_LETTER = 'f93687ad-d1e3-4577-83e9-1f5db0748d38';
+    public const NOTIFY_TEMPLATE_DOWNLOAD_RR2_LETTER = 'd43958ef-4a93-4cd8-abda-c4001785e740';
+    public const NOTIFY_TEMPLATE_DOWNLOAD_RR3_LETTER = '19610ca0-0225-423a-8f83-729be739be66';
+    public const NOTIFY_TEMPLATE_DOWNLOAD_FN14_LETTER = '08a7256f-921c-4cff-a4ef-70d50e2b1847';
+    public const NOTIFY_EMAIL_HEALTH_AND_WELFARE = '9b1dfc66-8ccb-4db8-b4e7-17f03f487874';
+    public const NOTIFY_EMAIL_PFA_LAY = '27e5deb5-8ea0-4d91-83d1-ae4145c351f9';
+    public const NOTIFY_EMAIL_PFA_PRO = '3e6753b7-6602-4363-8c9a-c88d02b239ba';
+    public const NOTIFY_EMAIL_PFA_PA = 'd8b4e115-5688-4161-82ca-82a93344a21f';
+    public const NOTIFY_EMAIL_FINANCE = 'f1e5faf6-e6aa-4beb-b6b8-cfa418482653';
 
     public function __construct(Filesystem $filesystem, Client $notifyClient)
     {
@@ -60,7 +60,13 @@ class SendToNotifyHandler
         try {
             $contents = $this->filesystem->read($pdf);
         } catch (UnableToReadFile $e) {
-            throw new UnexpectedValueException("Cannot read PDF: " . $e->getMessage());
+            $message = "Cannot read PDF";
+            do {
+                $message .= ': ' . $e->getMessage();
+                $e = $e->getPrevious();
+            } while (!is_null($e));
+
+            throw new UnexpectedValueException($message);
         }
 
         // 3. Send to notify

--- a/src/bootstrap/config.php
+++ b/src/bootstrap/config.php
@@ -13,7 +13,7 @@ return [
             'use_path_style_endpoint' => getenv('AWS_S3_USE_PATH_STYLE_ENDPOINT') ?
                 filter_var(getenv('AWS_S3_USE_PATH_STYLE_ENDPOINT'), FILTER_VALIDATE_BOOLEAN) : false,
             'bucket' => getenv('AWS_S3_BUCKET') ?: 'localbucket',
-            'prefix' => '/',
+            'prefix' => '',
             'options' => [
                 'ServerSideEncryption' => 'AES256',
             ]

--- a/src/bootstrap/services.php
+++ b/src/bootstrap/services.php
@@ -6,7 +6,7 @@ use Alphagov\Notifications\Client;
 use GuzzleHttp\Client as GuzzleClient;
 use Aws\S3\S3Client;
 use Aws\Sqs\SqsClient;
-use League\Flysystem\AwsS3v3\AwsS3Adapter;
+use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
 use League\Flysystem\Filesystem;
 use NotifyQueueConsumer\Authentication\JwtAuthenticator;
 use NotifyQueueConsumer\Command\Handler\SendToNotifyHandler;
@@ -41,10 +41,12 @@ try {
     throw $ex;
 }
 
-$adapter = new AwsS3Adapter(
+$adapter = new AwsS3V3Adapter(
     $awsS3Client,
     $config['aws']['s3']['bucket'],
     $config['aws']['s3']['prefix'],
+    null,
+    null,
     $config['aws']['s3']['options']
 );
 $filesystem = new Filesystem($adapter);

--- a/tests/functional/NotifyQueueConsumerTest/Queue/ConsumerTest.php
+++ b/tests/functional/NotifyQueueConsumerTest/Queue/ConsumerTest.php
@@ -268,13 +268,13 @@ class ConsumerTest extends TestCase
         $content = file_get_contents(self::TEST_FILE_PATH);
         $destination = basename(self::TEST_FILE_PATH);
 
-        $this->filesystem->put($destination, $content);
+        $this->filesystem->write($destination, $content);
 
         $this->awsSqsClient->sendMessage(
             [
                 'QueueUrl' => $this->queueUrl,
                 'MessageBody' => sprintf(
-                    '{"message":{"uuid":"%s","filename":"%s","documentId":"%d", 
+                    '{"message":{"uuid":"%s","filename":"%s","documentId":"%d",
                     "recipientEmail":"%s", "recipientName":"%s", "clientFirstName":"%s", "clientSurname":"%s",
                     "sendBy":{"method": "%s", "documentType": "%s"}, "letterType":"%s", "pendingOrDueReportType":"%s",
                      "caseNumber":"%s", "replyToType":"%s"}}',

--- a/tests/unit/NotifyQueueConsumerTest/Command/Handler/SendToNotifyHandlerTest.php
+++ b/tests/unit/NotifyQueueConsumerTest/Command/Handler/SendToNotifyHandlerTest.php
@@ -9,8 +9,8 @@ use Alphagov\Notifications\Exception as NotifyException;
 use Closure;
 use Exception;
 use JetBrains\PhpStorm\ArrayShape;
-use League\Flysystem\FileNotFoundException;
 use League\Flysystem\Filesystem;
+use League\Flysystem\UnableToReadFile;
 use NotifyQueueConsumer\Command\Handler\SendToNotifyHandler;
 use NotifyQueueConsumer\Command\Model\SendToNotify;
 use NotifyQueueConsumer\Queue\DuplicateMessageException;
@@ -37,9 +37,6 @@ class SendToNotifyHandlerTest extends TestCase
         );
     }
 
-    /**
-     * @throws FileNotFoundException
-     */
     public function testRetrieveQueueMessageSendToNotifyPostLetterAndReturnCommandSuccess(): void
     {
         $data = $this->getData('post', 'letter', null, null);
@@ -103,7 +100,6 @@ class SendToNotifyHandlerTest extends TestCase
 
     /**
      * @dataProvider financeInvoiceLetterData
-     * @throws FileNotFoundException
      */
     public function testRetrieveQueueMessageSendToNotifyEmailInvoiceAndReturnCommandExpected(string $letterType, string $letterTemplate, string $replyToType): void
     {
@@ -140,7 +136,6 @@ class SendToNotifyHandlerTest extends TestCase
 
     /**
      * @dataProvider annualReportLetterData
-     * @throws FileNotFoundException
      */
     public function testRetrieveQueueMessageSendToNotifyEmailLetterAndReturnCommandExpected(string $letterType, string $letterTemplate, ?string $replyToType): void
     {
@@ -151,7 +146,6 @@ class SendToNotifyHandlerTest extends TestCase
 
     /**
      * @param Exception $notifyException
-     * @throws FileNotFoundException
      * @dataProvider notifyExceptionProvider
      */
     public function testSendToNotifyBubblesUpApiExceptionFailure(Closure $notifyExceptionClosure): void
@@ -214,9 +208,6 @@ class SendToNotifyHandlerTest extends TestCase
         ];
     }
 
-    /**
-     * @throws FileNotFoundException
-     */
     public function testRetrieveDuplicateMessageThrowsExceptionFailure(): void
     {
         $data = $this->getData('post', 'letter', 'a6', 'HW');
@@ -248,26 +239,20 @@ class SendToNotifyHandlerTest extends TestCase
         $this->handler->handle($command);
     }
 
-    /**
-     * @throws FileNotFoundException
-     */
     public function testEmptyPdfInQueueFailure(): void
     {
         $data = $this->getData('post', 'letter', null, null);
 
         $command = SendToNotify::fromArray($data);
 
-        $this->mockFilesystem->method('read')->willReturn(false);
+        $this->mockFilesystem->method('read')->willThrowException(new UnableToReadFile("file does not exist"));
 
         self::expectException(UnexpectedValueException::class);
-        self::expectExceptionMessage("Cannot read PDF");
+        self::expectExceptionMessage("Cannot read PDF: file does not exist");
 
         $this->handler->handle($command);
     }
 
-    /**
-     * @throws FileNotFoundException
-     */
     public function testNotifyResponseIdNotFoundFailure(): void
     {
         $data = $this->getData('post', 'letter', null, null);
@@ -299,9 +284,6 @@ class SendToNotifyHandlerTest extends TestCase
         $this->handler->handle($command);
     }
 
-    /**
-     * @throws FileNotFoundException
-     */
     public function testNotifyStatusNotFoundFailure(): void
     {
         $data = $this->getData('post', 'letter', null, null);
@@ -339,9 +321,6 @@ class SendToNotifyHandlerTest extends TestCase
         $this->handler->handle($command);
     }
 
-    /**
-     * @throws FileNotFoundException
-     */
     public function testRetrieveQueueMessageSendToNotifyEmailFailsWhenNoNotifyIdReturned(): void
     {
        $data = $this->getData('email', 'letter', 'a6', 'HW');
@@ -398,9 +377,6 @@ class SendToNotifyHandlerTest extends TestCase
         $this->handler->handle($command);
     }
 
-    /**
-     * @throws FileNotFoundException
-     */
     public function testRetrieveQueueMessageSendToNotifyEmailFailsWhenNoStatusRetrieved(): void
     {
         $data = $this->getData('email', 'letter', null, null);
@@ -537,7 +513,6 @@ class SendToNotifyHandlerTest extends TestCase
      * @param SendToNotify $command
      * @param array $payload
      * @return void
-     * @throws FileNotFoundException
      */
     public function notifyClientAndAssertions(
         array $response,
@@ -564,9 +539,6 @@ class SendToNotifyHandlerTest extends TestCase
         self::assertEquals($payload['notifySendId'], $command->getNotifyId());
     }
 
-    /**
-     * @throws FileNotFoundException
-     */
     public function setupForInvoiceAndLettersWithAssertions(array $data, string $letterTemplate): void
     {
         $contents = "pdf content";

--- a/tests/unit/NotifyQueueConsumerTest/ConfigTest.php
+++ b/tests/unit/NotifyQueueConsumerTest/ConfigTest.php
@@ -31,7 +31,7 @@ class ConfigTest extends TestCase {
             ],
             'default_of_aws_s3_prefix' => [
                 function ($config) { return $config['aws']['s3']['prefix']; },
-                '/',
+                '',
             ],
             'default_of_aws_s3_options' => [
                 function ($config) { return $config['aws']['s3']['options']; },


### PR DESCRIPTION
Upgrade `league/flysystem` and `league/flysystem-aws-s3-v3`.

- Update `services.php` to update AWS adapter
- Update `SendToNotifyHandler` to handle v3 exceptions
- Stop suggesting `FileNotFoundException` will be thrown when it won't
- Update `ConsumerTest` to use `write` method ("put" has been removed)
- Stop adding a "/" prefix to paths: this causes duplicate slashes which leads to 404 errors
- Improve logging of wrapped error messages so we can see the underlying cause of an issue

[Here is a diff](https://github.com/ministryofjustice/opg-notify-queue-consumer/compare/eeb98d227abefc74e2dbba025af9e2b08ce68acb..CTC-11-upgrade-flysystem-v3) of the changes between my first attempt at this and this PR.

For CTC-11 #minor